### PR TITLE
add instructions directly to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # Binary Search Tree Practice (JavaScript)
-See the [Ruby version](https://github.com/AdaGold/tree-practice) for details.
+In this exercise you will implement, in JavaScript, several Tree methods.
+
+- `add(value)` - This method adds a key-value pair to the Binary Search Tree
+- `find(value)` - This method returns the matching value for the given key if it is in the tree and `None` if the key is not found in the tree.
+-  **Traversals**:  These methods return an array of objects consisting of all the key-value pairs in the tree in a specific order.
+    - `inorder` - This method returns an array of all the elements in the tree, in order.
+    - `postorder` - This method returns an array of all the elements in a postorder fashion (left, right , root).
+    - `preorder` - This method returns an array of all the elements in a preorder fashion (root, left, right).
+- `height` - This method returns the height of the binary search tree.
+
+## Optionals
+
+- `bfs` - This method returns an array with the tree elements in a level-by-level order (see [Breadth-First traversal](https://medium.com/basecs/breaking-down-breadth-first-search-cebe696709d9))
 
 ## Installation
 This has been tested with node `12.10.0`. To install, run


### PR DESCRIPTION
Update README to directly include implementation instructions instead of linking to README for python version